### PR TITLE
商品情報編集機能追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,24 +21,24 @@ class ItemsController < ApplicationController
     end
   end
 
-  #def edit
+  def edit
     # ログインしているユーザーと同一であればeditファイルが読み込まれる
-  #  if @item.user_id == current_user.id && @item.order.nil?
-  #  else
-  #    redirect_to root_path
-  #  end
-  #end
+    if @item.user_id == current_user.id #&& @item.order.nil?
+    else
+      redirect_to root_path
+    end
+  end
 
-  #def update
-  #  @item.update(item_params)
+  def update
+    @item.update(item_params)
     # バリデーションがOKであれば詳細画面へ
-  #  if @item.valid?
-  #    redirect_to item_path(item_params)
-  #  else
+    if @item.valid?
+      redirect_to item_path(item_params)
+    else
       # NGであれば、エラー内容とデータを保持したままeditファイルを読み込み、エラーメッセージを表示させる
-  #    render 'edit'
-  #  end
-  #end
+      render 'edit'
+    end
+  end
 
   def show
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,7 +33,7 @@ class ItemsController < ApplicationController
     @item.update(item_params)
     # バリデーションがOKであれば詳細画面へ
     if @item.valid?
-      redirect_to item_path(item_params)
+      redirect_to item_path(@item)
     else
       # NGであれば、エラー内容とデータを保持したままeditファイルを読み込み、エラーメッセージを表示させる
       render 'edit'

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -139,11 +139,11 @@ app/assets/stylesheets/items/new.css %>
       </p>
     </div>
     <%# /注意書き %>
-    
+
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%= link_to 'もどる', root_path, class:"back-btn" %>
+      <%= link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -27,6 +27,7 @@ app/assets/stylesheets/items/new.css %>
       </div>
     </div>
     <%# /商品画像 %>
+
     <%# 商品名と商品説明 %>
     <div class="new-items">
       <div class="weight-bold-text">
@@ -138,6 +139,7 @@ app/assets/stylesheets/items/new.css %>
       </p>
     </div>
     <%# /注意書き %>
+    
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id #&& @item.order.nil? %> 
-        <%= link_to "商品の編集", "edit_item_path(@item)", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "item_path(@item)", method: :delete, class:"item-destroy" %>
 


### PR DESCRIPTION
# What
商品情報編集機能の実装確認依頼

# Why
商品情報編集機能を追加実装したため

・ログイン状態の出品者は、商品情報編集ページに遷移できる動画
URL(https://gyazo.com/fd67cb2ba1513ae224264f925fc874ef)
・必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
URL(https://gyazo.com/09d94abbf95d0e65e7160d3a56c275af)
・入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
URL(https://gyazo.com/5d840de1d60ab7a5f484830c7ff94e7e) 
・何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
URL(https://gyazo.com/5c03c2f89bb4747410638125b3c99fd2)
・ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
URL(https://gyazo.com/e693108a9fd88c8b41074091caf8bf27)
ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
　→購入機能実装前のため今回は無し
・ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
URL(https://gyazo.com/970352c5a142c7a9889b0b1320f393c8)
・商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
URL(https://gyazo.com/1295bce4a3883b91650c40a56fb689bd)
